### PR TITLE
feat: add space-master skill, env template, and plugin improvements

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,66 @@
-# Wopal Plugin
+# Wopal Plugin — Environment Configuration
+# Copy this file to $WOPAL_HOME/.env or <space>/.wopal/.env and fill in your values.
+#
+# Loading order (higher priority overrides lower):
+#   1. process.env (pre-existing, never overwritten)
+#   2. <space>/.wopal/.env (space-level)
+#   3. $WOPAL_HOME/.env (user-level, shared across spaces)
+#
+# ─── LLM (REQUIRED for memory distillation, deduplication, and session titles) ───
+# Without these, the memory system cannot initialize.
+# Set WOPAL_MEMORY_ENABLED=false if you don't need memory features.
+
+# OpenAI-compatible API endpoint
+WOPAL_LLM_BASE_URL=https://api.openai.com/v1
+
+# API key for the LLM service
+WOPAL_LLM_API_KEY=sk-your-key-here
+
+# Model name (default: gpt-4o-mini)
+# WOPAL_LLM_MODEL=gpt-4o-mini
+
+
+# ─── Embedding (REQUIRED for memory vector search) ───
+# Without these, the memory system cannot initialize.
+
+# OpenAI-compatible embedding API endpoint
+WOPAL_EMBEDDING_BASE_URL=https://api.openai.com/v1
+
+# Embedding model name
+WOPAL_EMBEDDING_MODEL=text-embedding-3-small
+
+# API key for the embedding service (default: "ollama" for local Ollama)
+# WOPAL_EMBEDDING_API_KEY=sk-your-key-here
+
+
+# ─── Feature Switches ───
+# All default to true. Set to "false" to disable.
+
+# Enable rule injection into system prompt
+# WOPAL_RULES_INJECTION_ENABLED=true
+
+# Enable the entire memory module (when off, MEMORY_INJECTION is also ignored)
+# WOPAL_MEMORY_ENABLED=true
+
+# Enable memory injection into system prompt
+# WOPAL_MEMORY_INJECTION_ENABLED=true
+
+
+# ─── Logging ───
+
 # Log level: trace | debug | info | warn | error | fatal (default: info)
-WOPAL_PLUGIN_LOG_LEVEL=info
-# Module filter: comma-separated module names (core|rules|task|memory|context), empty = no filter
-WOPAL_PLUGIN_LOG_MODULES=core
+# WOPAL_PLUGIN_LOG_LEVEL=info
+
+# Module filter: comma-separated (core | rules | task | memory | context), empty = all
+# WOPAL_PLUGIN_LOG_MODULES=
+
 # Log file path (default: <cwd>/.wopal-space/logs/wopal-plugin.log)
-WOPAL_PLUGIN_LOG_FILE=/tmp/wopal-plugin.log
+# WOPAL_PLUGIN_LOG_FILE=
+
+
+# ─── Prompt Templates (optional overrides) ───
+# Point to custom prompt files to override built-in defaults.
+
+# WOPAL_DISTILL_PROMPT_FILE=
+# WOPAL_DEDUP_PROMPT_FILE=
+# WOPAL_TITLE_PROMPT_FILE=

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -9,8 +9,9 @@
 
 | Date | Type | Summary |
 |---|---|---|
+| 2026-06-18 | Major | §6.8 完全重写：从版本化 manifest 驱动改为规则驱动设计。核心 6 条规则：单向下行合并、top-down 顺序、贡献走 squash merge 不强制 update、冲突即停、update 逻辑原子、配置隔离。去掉 manifest/版本号/ownership pattern/install/release/validate/apply 等机制，回归标准 git 工作流。命令族收敛为 6 个（ontology status/update/contribute + space status/update/contribute）。 |
+| 2026-06-17 | Major | §6.8 完全重写：从 git merge 驱动改为版本化 manifest 驱动同步。新增 Manifest 结构（ontology.yaml + space-manifest.yaml）、版本号规则（main 三位 + type 四位）、Release 流程、Update 机制（变更集应用 + ownership 保留）、Apply 机制（双向文件迁移）、Contribute 机制（临时分支隔离 + 选择性 apply + PR）、Space Update 机制。去掉 clone/fork 二分法、四层检测机制、git merge 同步。命令族新增 install、release、validate。 |
 | 2026-06-13 | Updated | §6.9 Agent Ontology Maintenance Workflow — 状态解读、更新决策、能力提升、多级 fork 维护和 safe-apply/contribute 工作流。补充 `/ontology-maintain` 命令。 |
-| 2026-06-13 | Updated | §6.8 — 重构 `ontology status`/`space status` 输出规范 |
 | 2026-05-31 | Updated | 收敛 base capabilities + space overlay：setup 从 ontology main 物化 base，space overlay 同名覆盖。 |
 | 2026-05-30 | Updated | 将 Git source / worktree 分发细节下沉到 `docs/DISTRIBUTION.md`。 |
 | 2026-05-29 | Updated | 明确 STRUCTURE compact schema、Design Document Layering 与 `/init` 消费 `wopal space scan` JSON 的维护边界。 |
@@ -471,17 +472,15 @@ Ontology 通过两层模型为 WopalSpace 提供可覆盖的能力分发：
 
 ### 6.8 Ontology 协作模型
 
-Ontology 以 Git 分支承载能力演化，形成自上而下的能力层级。每一层相对其父层，角色等同于特性分支——在本层做变更，通过 PR 贡献到父层。`wopal ontology` 命令族在两种模式下提供检查、更新和贡献操作。
+Ontology 以 Git 分支承载能力演化，形成自上而下的能力层级。同步机制基于**规则驱动**——用一套明确的操作规则约束用户和 agent 的行为，CLI 作为流程守卫强制执行规则，避免复杂的场景穷举验证。
 
-#### 分支层级
+#### 分层结构
 
 三层分支，自上而下叠加能力：
 
-- **通用类型分支（main）**：所有类型空间共享的基础能力，等同于 type/common。
-- **能力类型分支（type/*）**：在通用基线之上叠加特定类型的能力。如 type/coding 叠加编码类空间的能力，type/content 叠加自媒体类空间的能力。
-- **空间分支（space/*）**：在能力分支之上叠加单个空间的定制。如 space/wopal-workspace 基于 type/coding。
-
-空间分支是能力分支的超集，能力分支是通用类型分支的超集。每一层都完整包含父层的所有内容，加上自己特有的能力。
+- **通用基线（main）**：所有类型空间共享的基础能力。跟踪上游 main。
+- **能力类型分支（type/*）**：在 main 之上叠加特定类型的能力。type/* 是 main 的超集——包含 main 全部内容 + 类型能力。跟踪上游 type/*。
+- **空间分支（space/*）**：在 type/* 之上叠加单个空间的定制。space/* 是 type/* 的超集——包含 type/* 全部内容 + 空间定制。是 type/* 的实例分支。
 
 分支命名约定：
 
@@ -489,210 +488,109 @@ Ontology 以 Git 分支承载能力演化，形成自上而下的能力层级。
 |------|------|------|
 | 通用基线 | `main` | 所有空间共享 |
 | 能力分支 | `type/<name>` | 上游维护或用户自建 |
-| 空间分支 | `space/<space-name>` | 绑定到特定空间 |
-| 贡献分支 | `contribute/<target>/<topic>` | 临时，PR 合并后删除 |
+| 空间分支 | `space/<name>` | 绑定到特定空间 |
 | 开发分支 | `feature/<name>` | dev-flow worktree 使用，临时 |
 
-拓扑示意：
+#### Source 模型
+
+Ontology source 是去中心化的——任何 GitHub 仓库都可以是 source，没有权威中心。
+
+- 官方 upstream（`wopal-cn/wopal-space-ontology`）是默认 source
+- 任何人 fork 后可以自主发布，成为他人的 source
+- 用户可以安装多个 ontology source，创建 space 时选择哪个 source 和 type 分支
+- source 质量靠 GitHub star 和 fork 数量自然涌现，用户自行判断
+- `wopal ontology install <github-url>` 从任意仓库安装
+
+用户安装 source 后，local 工作副本位于 `~/.wopal/ontologies/<source-name>/`，包含 main 和 type/* 分支。space 创建时锁定所属 source 和 type 分支。
+
+#### 核心规则
+
+本体协作由 6 条核心规则约束。CLI 命令和 agent 操作指南都必须保证这些规则的执行。
+
+**规则 1：单向下行合并**
 
 ```
-上游 (wopal-cn/wopal-space-ontology)
-  ├── main                ← 通用基线
-  ├── type/coding         ← 编码类型能力分支
-  └── type/content        ← 自媒体类型能力分支
-
-~/.wopal/ontologies/wopal-space-ontology/  (本地仓库)
-  ├── main                ← 上游 main 镜像
-  ├── type/coding         ← 上游 type/coding 镜像
-  └── space/wopal-workspace  ← 空间分支（基于 type/coding）
-
-<space>/.wopal/           ← 对应 space/<space-name> 分支的 worktree
+upstream/main → main → type/coding → space/<name>
 ```
 
-fork 模式下，用户副本（`<user>/wopal-space-ontology`）作为 origin 插入上游和本地仓库之间，承担副本镜像角色。分支层级结构保持一致。
+- 下行更新只走这条链，用 `git merge`
+- 禁止反向 merge：space→type、type→main、local→upstream
+- 上行只用 squash merge（同仓库贡献）或 PR（跨仓库贡献）
 
-#### 两种模式
+**规则 2：top-down 顺序**
 
-用户与上游 ontology 的关系分为两种模式，决定使用门槛和贡献能力：
+更新必须从最上层开始，逐层往下：
 
-| 模式 | 定位 | 同步链 |
-|------|------|--------|
-| **Clone**（默认） | 消费：获取上游更新 | `上游 → 本地能力分支 → 空间分支`（两层下行）|
-| **Fork** | 消费 + 贡献 | `上游 → 用户副本 → 本地能力分支 → 空间分支`（三层下行）|
+`ontology update` 内部：
+1. merge `upstream/main → main`
+2. merge `main → type/coding`
+3. 任一步冲突即停
 
-clone 模式降低使用门槛，大多数用户的选择。fork 模式适合活跃贡献者，多一层副本镜像，贡献流程更直接。两种模式下分支命名和下行同步操作一致。
+`space update` 前置守卫：
+- 检查 type/coding 是否已合并最新 main
+- 未合并 → 拒绝执行，提示"请先 `ontology update`"
 
-上游 canonical URL：`https://github.com/wopal-cn/wopal-space-ontology`。
+跳步会产生复杂历史，是错的根源。
 
-#### 更新流程（下行同步）
+**规则 3：贡献走 squash merge，不强制先 update**
 
-更新是把上游的新内容应用到用户的空间分支。这是最常用的操作。
+上行贡献分两个场景：
 
-**内容流动的三层关系**：上游维护各 type/* 始终包含 main 的最新内容；用户从远程拉取 main 和 type/* 到本地；再从本地 type/* 应用到空间分支。
+**同仓库（space → type/coding）**：用 `git merge --squash`。把 space 相对 type/coding 的全部变更压成一次暂存，不自动提交。预览后排除不该贡献的文件，用户确认后 commit。
 
-**第一步：ontology update（HOME 级，同步本体仓库）**
+**跨仓库（fork → upstream）**：创建临时分支基于 upstream 最新 → `git merge --squash` fork 分支 → 预览排除 → commit → `gh pr create`。
 
-从远程拉取 main 和所有 type/* 分支的最新内容到本地仓库。基于 check 的四层检测结果驱动——只同步有 downstream 信号的内容，不盲目 merge。
+贡献前不强制 update——squash merge 只带 diff，PR 用临时分支隔离，fork 分支不被碰，不需要先同步。
 
-clone 模式：fetch origin，对有 downstream 信号的分支执行 merge（允许 merge commit）。
+**规则 4：冲突即停**
 
-fork 模式：fetch upstream + origin，两层同步——先同步 fork 副本镜像，再同步到本地。完成后 push 副本镜像确保三层对齐。
+任何 merge / squash merge 冲突：
+- CLI 立即停止
+- 报告冲突文件列表
+- agent 手动编辑 → `git add` + `git commit` 完成
+- 永远不自动解决
 
-完成后，本地仓库拥有最新的 main 和 type/* 镜像。这一步操作本体仓库，发生在空间之外。
+**规则 5：update 多步顺序执行**
 
-**第二步：space update（Space 级，应用到空间）**
+`ontology update` 内部多步（main merge + type/coding merge）按顺序执行。任一步冲突 → 停在该点，不继续后续步骤。agent 手动解决冲突并 commit 完成该步 merge 后，重跑 `ontology update`，CLI 跳过已完成的步骤，从下一步继续。
 
-从本地能力类型分支（type/*）同步到当前空间分支。在 space worktree 中执行 merge，允许 merge commit。check 的第四层（merge-tree 冲突预测）在执行前判断冲突——clean 时自动 merge，有冲突时报告冲突文件由 agent 解决。
-
-**两步之间的关系**：先更新本体仓库（拿到最新能力分支），再应用到空间。中间可以检查更新内容、验证兼容性。两条命令解耦，分别在不同上下文执行。
-
-**超集不变量**：main 的变更需要手动下行到 type/*。上游维护者负责把 main 的内容合并到各 type/* 分支，确保 type/* 始终是 main 的超集。fork 用户在自己仓库上贡献 main 层变更后，同样需要手动执行这步，然后 push 到副本。check 的 D5 段检测超集是否成立——FAIL 时需要 merge main 到 type/* 修复。
-
-**合并策略**：允许 merge commit，不限制 fast-forward。能力分支和空间分支有自定义提交是常态，fast-forward 在多数场景下不可行。
-
-#### 检查流程（双向检查）
-
-检查帮助用户发现需要操作的信号。判断基于**内容一致性**——比较分支的完整内容状态，而非提交数量。合并采纳方式导致提交历史天然不同，比较提交数量会产生虚假的"有更新"报告。
-
-**向下检查（有无更新需要同步）**：
-
-逐层检查同步链上是否有待同步的内容。四类比较覆盖完整的下行链路：
-
-fork 模式：
-
-| # | 比较 | 类型 | 语义 |
-|---|------|------|------|
-| 1 | 上游 main/type/* ↔ 副本 main/type/* | 同镜像 | 副本镜像是否落后上游 |
-| 2 | 副本 main/type/* ↔ 本地 main/type/* | 同镜像 | 本地是否落后副本 |
-| 3 | 本地 main → 本地 type/* | 跨层父→子 | 能力分支是否包含通用基线全部内容（超集不变量）|
-| 4 | 本地 type/* → 空间分支 | 跨层父→子 | 空间分支是否落后能力类型分支 |
-
-clone 模式去掉比较 1、2 中的副本层（直接上游↔本地），比较 3、4 不变。
-
-**比较 3（超集不变量）的核心价值**：用户通常在 type→space 分支工作，产生的变更 PR 到 type。但 main（公共基线）的演进对 type 不可见——如果 main 变了而 type 没有及时下行传播，type 分支会长期落后 main，积压大量公共变更。超集不变量检查及时发现这种不同步，避免公共能力变更被遗漏。
-
-**新增能力分支检测**：除了已有分支的内容更新，还检查上游是否有本地尚未安装的新能力分支（如上游新增了 type/security）。检测到新分支时报告"新能力分支可用"，建议通过 ontology update 安装。
-
-**比较机制（四层组合，适用于所有层级）**：
-
-判断内容差异不能依赖 commit 比对（`git cherry` / patch-ID）。squash merge 导致同一变更在不同分支上有不同 SHA，两个分支内容可以完全一致但 commit 历史不同——commit 比对会产生虚假的"有差异"报告。比较必须基于**文件内容**，分四层逐步深入：
-
-第一层——内容指纹门控（`git rev-parse <ref>^{tree}`）：比较分支的完整内容指纹（tree hash）。指纹相同则内容完全一致，标记"一致"并跳过后续分析。指纹不同则进入第二层。
-
-第二层——文件内容比对（`git diff <A> <B> --diff-filter`）：逐文件比较内容差异，区分三种类型：`A`（一方有、另一方没有）、`M`（两边都有但内容不同）、`D`（一方删除）。
-
-第三层——差异方向判断（`merge-base` + `git log`）：对每个有差异的文件，判断方向和时效性。`git cat-file -e <merge-base>:<file>` 检查文件在共同祖先是否存在——存在说明是一方主动删的（上行信号），不存在说明是另一方新增的（下行信号）。`git log <merge-base>..<upstream> -- <file>` 检查上游在共同祖先之后是否更新过——未更新说明删除不会过时，更新过说明可能错过上游变更。
-
-第四层——合并冲突预测（`git merge-tree --write-tree <child> <parent>`）：对有差异的分支对，无副作用地预测 merge 结果。这个命令不改变工作树、不创建 commit，只输出 merge 后的 tree hash 或冲突文件列表。agent 据此判断 merge 能否安全自动执行，还是需要手动解决冲突。
-
-四层组合才能准确回答"这个差异要不要管"和"处理起来会不会冲突"。任何单一命令都无法一步到位——`git diff` 发现差异但不判断方向，`merge-base` 判断方向但不发现差异，`git log` 看历史但不比较内容，`git merge-tree` 预测冲突但不告诉你差异的含义。
-
-`git cherry`（patch-ID）仅作为辅助工具：在需要识别"哪个 commit 产生了某文件差异"以便 cherry-pick 时使用，不作为内容差异判断的依据。
-
-检测到差异时，按分支维度逐环节列出完整信息（文件清单、差异类型、方向判断），不输出操作建议——CLI 没有语义判断能力，无法区分"该同步的下行差异"和"本地主动变更"。
- 
-**向上检查（有无待贡献或待同步的变更）**：
-
-发现两类信号：
-
-1. **空间分支上有未贡献的变更**：空间分支相对对应能力类型分支，有哪些文件内容还没有回流？通过文件内容比对（`git diff`）识别空间分支独有的文件，再用 `merge-base` 判断方向（区分空间新增 vs 能力分支删除的）。帮助用户判断"我积累了哪些值得贡献的通用变更"。
-
-2. **能力类型分支与副本/上游的一致性**：fork 模式下，本地能力类型分支相对副本是否有未推送的变更？副本相对上游是否有待同步的差异？帮助用户判断"我的贡献是否已经传播到位"。
-
-**操作建议由 agent 判断**：
-
-check 只输出完整差异信息（文件清单、差异类型、方向判断），不输出操作建议。CLI 没有语义判断能力，无法区分"该同步的下行差异"和"本地主动变更"——例如 fork 主动重构删除的文件，diff 会报告"上游有、本地没有"，但不应同步。操作建议由 agent 基于完整信息推导。
-
-**触发方式**：手动运行 `ontology check`。
-
-#### 贡献流程（上行贡献）
-
-贡献是把空间分支上的通用变更回流到父层。仅面向 fork 模式用户。
-
-**核心设计决策**：所有上行回流采用 PR merge（squash merge），不直接本地 merge。space 相当于 type/coding 的特性分支，PR merge 保证父层提交历史清晰——每个 PR 在父层产生一个干净的提交，不会混入空间的定制变更。
-
-**上行链条**：上行是链条，内容必须逐级向上流动，顺序不能跳过：
-
-| 段 | 方向 | 操作方式 |
-|----|------|---------|
-| U1 | space → type/coding | PR（squash merge），保证 type 分支历史清晰 |
-| U2/U3 | local → origin | push |
-| U4/U5 | origin → upstream | PR（跨仓库） |
-
-U1 完成后才能 U2/U3（push 回流后的变更），U2/U3 完成后才能 U4/U5（从 fork 向上游发 PR）。
-
-**贡献路径**——根据变更的适用范围决定目标层：
-
-| 变更适用范围 | 贡献到 | 方式 |
-|-------------|--------|------|
-| 同类空间通用（如所有 coding 类空间）| 对应能力分支（type/coding）| 直接 PR 或精选 PR |
-| 所有空间通用 | 通用基线（main）| 精选 PR（贡献分支）|
-| 本空间特有 | 不贡献 | 留在空间分支 |
-
-**直接 PR**：空间分支相对父层的差异全是通用变更时，直接从空间分支创建 PR 到父层。配置隔离约定保证了差异天然干净。PR 采用合并采纳（squash merge），每个 PR 在父层产生一个清晰的提交。
-
-**精选 PR**：空间分支上混合了通用变更和空间私有变更时，或需要跨层贡献（如 coding 空间向 main 贡献单个修复）时，使用贡献分支精选：
-
-1. 从目标层创建贡献分支（如 `contribute/main/<topic>`）
-2. cherry-pick 想贡献的提交到贡献分支
-3. PR 贡献分支到目标层
-
-贡献分支是临时分支，PR 合并后删除。它让你精准贡献——只贡献想贡献的变更，不受源分支上其他内容的干扰。
-
-**逐层传播**：变更进入通用类型分支（main）后，需要手动下行传播到能力类型分支。仓库维护者执行 `apply --from main --to type/coding`，把 main 的变更合并到能力分支，然后 push。其他用户通过日常更新流程（ontology update + space update）获得传播后的内容。
-
-**提交描述规范**：PR 采用合并采纳，提交标题遵循 Conventional Commits 格式。GitHub 自动追加 PR 编号（如 `feat(dev-flow): add validation shortcuts (#123)`），提供来源追溯。父层的提交历史呈现为每个 PR 一个提交的清晰序列。
-
-#### 配置隔离约定
+**规则 6：配置隔离与 .gitignore 一致性**
 
 空间分支相对父层的差异只包含能力变更，由配置文件的分层约定保证：
 
 - `settings.jsonc`：公共配置，随分支传播，所有层级共享。
-- `settings.local.json`：空间私有配置，被 git 忽略，保留在本地文件系统。
+- `settings.local.jsonc`：空间私有配置，被 git 忽略，保留在本地文件系统。
 
-因此，空间分支向父层的 PR 天然干净——只包含能力层面的变更。
+每个分支（main、type/*、space/*）都有自己的 `.gitignore`，声明该分支忽略的文件清单。分支间基本一致，差异不大。space 分支的 `.gitignore` 必须与其所属 type/* 分支一致——如果不一致，视为当前变更，需要同步一致（squash merge 上行或 reset 回来）。这保证被忽略的私有文件在 merge 时不受影响。
 
 #### 命令总览
 
-ontology 维护涉及以下命令。详细参数和输出格式见 wopal-cli 设计文档。
+| 命令 | 方向 | 底层操作 | CLI 守卫 |
+|------|------|---------|---------|
+| `ontology status` | — | 下行/上行全链路 git log/diff 展示差异 + `git merge-tree` 预测 merge 结果 | — |
+| `ontology update` | 下行 | `git merge upstream/main → main` + `git merge main → type/coding` | 强制顺序，冲突即停 |
+| `ontology contribute` | 上行 | 创建临时分支 + squash merge + PR | fork 分支不被碰 |
+| `space status` | — | 当前 space 相关的完整链路 git log/diff 展示差异 + `git merge-tree` 预测 merge 结果 | — |
+| `space update` | 下行 | `git merge type/coding → space` | 前置检查 type 已更新 |
+| `space contribute` | 上行 | `git merge --squash space → type/coding` | 预览排除，不自动提交 |
 
-**检查与查看**：
-
-- `ontology check`——基于内容一致性检测各层级更新状态。只读，手动触发。向下看有无更新，向上看有无未推送变更。
-- `ontology status`——查看当前空间的分支身份和同步状态。
-- `ontology list`——查看所有已注册的 ontology 源的全局视图。
-
-**更新**：
-
-- `ontology update`——从上游或副本同步能力分支到本地仓库（HOME 级）。
-- `space update`——从本地能力分支同步到空间分支（Space 级）。
-
-**贡献**：
-
-- `contribute`——精选提交到贡献分支，提交 PR 到父层。
-- `apply`——分支间通用合并工具，适用于需要手动控制方向的场景。
-
-**约束**：贡献仅 fork 模式；所有上行回流采用 PR merge（squash merge）；下行同步允许 merge commit，不限制 fast-forward。
+所有命令 context-aware——在 space 目录运行时自动定位关联的 ontology source 和 type 分支。用户不需要切到 ontology repo。
 
 #### AI 辅助流程
 
-Agent 是本体维护的决策中枢。CLI 输出四层检测的结构化事实，agent 解读后与用户讨论，再构造命令执行。详细操作规则（什么信号用什么命令、上下行执行步骤、冲突解决策略、贡献路径选择）见 space-master 技能的本体维护操作指南。
+Agent 是本体维护的决策中枢。CLI 输出分支差异的结构化事实，agent 解读后与用户讨论，再构造命令执行。详细操作规则见 space-master 技能的本体维护操作指南。
 
-**决策框架**（基于 check 四层检测信号）：
+**决策框架**：
 
-1. worktree 有未提交变更 → 先提交
-2. check 有 downstream 信号（D1-D4）+ merge-tree clean → 执行 ontology update
-3. check 有 downstream 信号 + merge-tree conflicts → cherry-pick 具体变更，agent 手动解决冲突
-4. D5 超集检查 FAIL → merge main 到 type/coding 修复超集违反
-5. D6 显示 space 落后 type/coding → 执行 space update
-6. check 有 upstream 信号（U1）→ 与用户讨论哪些空间变更有普遍价值，值得贡献
-7. U1 确认贡献 → 按 U1 → U2/U3 → U4/U5 链条逐级上行
+1. `ontology status` 显示 upstream → local 落后 → 执行 `ontology update`
+2. update 冲突 → agent 手动解决冲突文件，重跑 update 继续
+3. `space status` 显示 type/coding → space 落后 → 执行 `space update`
+4. space 有修改想贡献到 type → `space contribute`（squash merge + 预览排除）
+5. 想贡献回 upstream → `ontology contribute`（临时分支 + PR）
 
-**冲突处理**：check 的第四层（merge-tree 冲突预测）在执行前判断冲突。clean 时 CLI 自动 merge；conflicts 时报告冲突文件，agent 手动编辑解决（保留双方有价值的改动），然后 `git add` + `git commit` 完成 merge。
+**冲突处理**：所有冲突（update、contribute）统一由 agent 解决。CLI 报告冲突文件，agent 手动编辑后继续命令。
 
-**多级副本链**：用户的副本可被他人 fork 为上游。CLI 自动从 `upstream` remote 拉取，多级副本链对 CLI 透明。
-
-**`/ontology-maintain` 命令**：Agent 使用此命令触发完整维护流程——check（四层检测）→ 分析建议（按决策框架排序）→ 报告确认（等待用户确认）→ 执行操作（每次操作后验证）。
+**`/ontology-maintain` 命令**：Agent 使用此命令触发完整维护流程——status（差异对比）→ 分析建议（按决策框架排序）→ 报告确认（等待用户确认）→ 执行操作（每次操作后验证）。
 
 ---
 ## 7. Data and State Model

--- a/plugins/wopal-plugin/src/index.ts
+++ b/plugins/wopal-plugin/src/index.ts
@@ -83,8 +83,29 @@ let _memorySystem: {
   llm: import("./llm-client").LLMClient;
 } | null = null;
 
+/** Check required env vars for memory system. Returns list of missing var names. */
+function diagnoseMemoryEnv(): string[] {
+  const required = [
+    "WOPAL_LLM_BASE_URL",
+    "WOPAL_LLM_API_KEY",
+    "WOPAL_EMBEDDING_BASE_URL",
+    "WOPAL_EMBEDDING_MODEL",
+  ];
+  return required.filter((v) => !process.env[v]);
+}
+
 async function ensureMemorySystem(): Promise<typeof _memorySystem> {
   if (_memorySystem) return _memorySystem;
+
+  const missing = diagnoseMemoryEnv();
+  if (missing.length > 0) {
+    coreLogger.warn(
+      `Memory system disabled: missing env vars (${missing.join(", ")}). ` +
+      `Set them in $WOPAL_HOME/.env or <space>/.wopal/.env. ` +
+      `Set WOPAL_MEMORY_ENABLED=false to suppress this warning.`
+    );
+    return null;
+  }
 
   try {
     const { MemoryStore } = await import("./memory/store");

--- a/scripts/emt
+++ b/scripts/emt
@@ -12,21 +12,72 @@ export OPENCODE_EXPERIMENTAL=true
 
 hash -r 2>/dev/null || true
 
+if ! command -v ellamaka > /dev/null 2>&1; then
+    echo "emt: 找不到 ellamaka 命令，请检查 PATH 或 WOPAL_HOME/bin" >&2
+    exit 1
+fi
+if ! command -v tmux > /dev/null 2>&1; then
+    echo "emt: 找不到 tmux 命令，请安装 tmux" >&2
+    exit 1
+fi
+if ! command -v python3 > /dev/null 2>&1; then
+    echo "emt: 找不到 python3 命令" >&2
+    exit 1
+fi
+if ! command -v curl > /dev/null 2>&1; then
+    echo "emt: 找不到 curl 命令" >&2
+    exit 1
+fi
+if ! command -v lsof > /dev/null 2>&1; then
+    echo "emt: 找不到 lsof 命令" >&2
+    exit 1
+fi
+
+if ! command -v tmux > /dev/null 2>&1; then
+    echo "emt: 找不到 tmux 命令，请安装 tmux" >&2
+    exit 1
+fi
+
 SCRIPT_PATH="$(python3 -c 'import os,sys; print(os.path.realpath(sys.argv[1]))' "${BASH_SOURCE[0]}")"
 SCRIPT_DIR="$(dirname "$SCRIPT_PATH")"
 AUTO_APPROVE_SCRIPT="$SCRIPT_DIR/oc-auto-approve.py"
 
 CWD="$(pwd)"
-SPACE_ROOT="$(dirname "$(dirname "$SCRIPT_DIR")")"
-LOG_DIR="$SPACE_ROOT/.wopal-space/logs"
+
+detect_wopal_space_root() {
+  local dir="$1"
+  while true; do
+    if [ -f "$dir/.wopal/.git" ]; then
+      echo "$dir"
+      return 0
+    fi
+    [ "$dir" = "/" ] && break
+    [ "$dir" = "$HOME" ] && break
+    dir="$(dirname "$dir")"
+  done
+  return 1
+}
+
+WOPAL_HOME_DIR="${WOPAL_HOME:-$HOME/.wopal}"
+GLOBAL_LOG_DIR="$WOPAL_HOME_DIR/logs"
+BACKEND_STATE_DIR="$WOPAL_HOME_DIR/ellamaka/state"
+
+if SPACE_ROOT="$(detect_wopal_space_root "$CWD")"; then
+  SPACE_LOG_DIR="$SPACE_ROOT/.wopal-space/logs"
+else
+  SPACE_LOG_DIR=""
+fi
+
+mkdir -p "$GLOBAL_LOG_DIR" "$BACKEND_STATE_DIR"
+[ -n "$SPACE_LOG_DIR" ] && mkdir -p "$SPACE_LOG_DIR"
+
 SESSION_NAME="em-$(basename "$CWD")"
 
 BACKEND_PORT=4096
-ELLAMAKA_LOG="$LOG_DIR/ellamaka.log"
-BACKEND_LOG="$LOG_DIR/emt-backend.log"
-BACKEND_PID_FILE="$LOG_DIR/emt-backend.pid"
+BACKEND_PID_FILE="$BACKEND_STATE_DIR/emt-backend.pid"
+ELLAMAKA_LOG="${SPACE_LOG_DIR:-$GLOBAL_LOG_DIR}/ellamaka.log"
 
-NO_AUTO_APPROVE=false DEBUG_MODE=false ATTACH_MODE=false NO_WOPAL_SPACE=false
+NO_AUTO_APPROVE=false DEBUG_MODE=false ATTACH_MODE=false DISABLE_WOPALSPACE=false
 DEBUG_MODULES=""
 TRACE_MODE=false TRACE_MODULES=""
 COMMAND=""
@@ -64,7 +115,7 @@ while [[ $# -gt 0 ]]; do
     case "$1" in
         --help|-h) OPENCODE_ARGS+=(--help); shift ;;
         --no-auto-approve) NO_AUTO_APPROVE=true; shift ;;
-        -ns) NO_WOPAL_SPACE=true; shift ;;
+        -ns) DISABLE_WOPALSPACE=true; shift ;;
 
         --trace)
             TRACE_MODE=true; DEBUG_MODE=true
@@ -109,8 +160,8 @@ fi
 # "all" = 不做模块过滤，留空让 logger 视为 null（不过滤）
 [[ "$LOG_MODULES" == "all" ]] && LOG_MODULES=""
 
-if [ "$NO_WOPAL_SPACE" = true ]; then
-    WOPAL_SPACE_ARGS=(--no-wopal-space)
+if [ "$DISABLE_WOPALSPACE" = true ]; then
+    WOPAL_SPACE_ARGS=(--disable-wopalspace)
 else
     WOPAL_SPACE_ARGS=()
 fi
@@ -124,44 +175,77 @@ is_backend_running() {
 wait_backend() {
     for ((i = 0; i < 60; i++)); do
         curl -sf "http://127.0.0.1:$BACKEND_PORT/health" > /dev/null 2>&1 && return 0
+        # 等待期间检查后端是否已崩溃
+        if [ -f "$BACKEND_PID_FILE" ]; then
+            local check_pid
+            read -r check_pid < "$BACKEND_PID_FILE"
+            if ! kill -0 "$check_pid" 2>/dev/null; then
+                echo "" >&2
+                echo "emt: 后端在启动期间崩溃 (PID $check_pid)" >&2
+                local check_log
+                { read -r _; read -r _; read -r check_log || true; } < "$BACKEND_PID_FILE"
+                if [ -n "$check_log" ] && [ -f "$check_log" ]; then
+                    echo "emt: 日志尾部 ($check_log):" >&2
+                    tail -30 "$check_log" >&2
+                fi
+                rm -f "$BACKEND_PID_FILE"
+                return 2
+            fi
+        fi
         sleep 0.5
     done
     return 1
 }
 
-start_backend() {
-    mkdir -p "$LOG_DIR"
+# 检查刚启动的后端是否存活，若已崩溃则清理残留并输出日志尾部
+verify_backend_alive() {
+    local pid="$1" log="$2"
+    sleep 1
+    if ! kill -0 "$pid" 2>/dev/null; then
+        echo "" >&2
+        echo "emt: 后端启动失败 (PID $pid 已退出)" >&2
+        if [ -f "$log" ]; then
+            echo "emt: 日志尾部 ($log):" >&2
+            tail -30 "$log" >&2
+        fi
+        rm -f "$BACKEND_PID_FILE" "$log"
+        exit 1
+    fi
+}
 
+start_backend() {
     local log_level="INFO"
     [ "$DEBUG_MODE" = true ] && log_level="DEBUG"
 
     local serve_args=(serve --port $BACKEND_PORT --mdns --mdns-domain ellamaka.local --print-logs --log-level $log_level "${WOPAL_SPACE_ARGS[@]}")
 
-    nohup env \
-        WOPAL_PLUGIN_LOG_LEVEL="${LOG_LEVEL}" \
-        WOPAL_PLUGIN_LOG_MODULES="${LOG_MODULES}" \
-        WOPAL_PLUGIN_LOG_FILE="$LOG_DIR/wopal-plugins-debug.log" \
-        ellamaka "${serve_args[@]}" > "$BACKEND_LOG" 2>&1 &
+    # serve 日志路由：非 debug → 全局，debug → 空间
+    local backend_log="$GLOBAL_LOG_DIR/emt-backend.log"
+    local plugin_log_file=""
+    if [ "$DEBUG_MODE" = true ]; then
+        backend_log="${SPACE_LOG_DIR:-$GLOBAL_LOG_DIR}/emt-backend.log"
+        plugin_log_file="${SPACE_LOG_DIR:-$GLOBAL_LOG_DIR}/wopal-plugins-debug.log"
+    fi
 
-    # 记录 PID 和启动目录，stop 时用于校验
-    { echo $!; echo "$CWD"; } > "$BACKEND_PID_FILE"
+    local env_vars=(WOPAL_HOME="$WOPAL_HOME_DIR")
+    [ -n "$LOG_LEVEL" ] && env_vars+=(WOPAL_PLUGIN_LOG_LEVEL="$LOG_LEVEL")
+    [ -n "$LOG_MODULES" ] && env_vars+=(WOPAL_PLUGIN_LOG_MODULES="$LOG_MODULES")
+    [ -n "$plugin_log_file" ] && env_vars+=(WOPAL_PLUGIN_LOG_FILE="$plugin_log_file")
+
+    nohup env "${env_vars[@]}" ellamaka "${serve_args[@]}" > "$backend_log" 2>&1 &
+    local serve_pid=$!
+
+    # 记录 PID、启动目录、后端日志路径
+    { echo "$serve_pid"; echo "$CWD"; echo "$backend_log"; } > "$BACKEND_PID_FILE"
+
+    verify_backend_alive "$serve_pid" "$backend_log"
 }
 
 stop_backend() {
-    local pid="" start_dir="" has_pid_file=false
+    local pid="" start_dir="" backend_log=""
 
     if [ -f "$BACKEND_PID_FILE" ]; then
-        has_pid_file=true
-        { read -r pid; read -r start_dir; } < "$BACKEND_PID_FILE"
-
-        local current_dir="$(pwd)"
-        if [ "$current_dir" != "$start_dir" ]; then
-            echo "emt: 当前目录与启动目录不一致，无法停止后端" >&2
-            echo "  启动目录: $start_dir" >&2
-            echo "  当前目录: $current_dir" >&2
-            echo "  请 cd 到 $start_dir 后执行 emt stop" >&2
-            exit 1
-        fi
+        { read -r pid; read -r start_dir; read -r backend_log || true; } < "$BACKEND_PID_FILE"
     fi
 
     local port_pid
@@ -172,7 +256,7 @@ stop_backend() {
         return
     fi
 
-    rm -f "$BACKEND_PID_FILE" "$BACKEND_LOG" "$LOG_DIR/wopal-plugins-debug.log" || true
+    rm -f "$BACKEND_PID_FILE" "$backend_log" || true
 
     for p in $pid $port_pid; do
         [ -n "$p" ] && kill "$p" 2>/dev/null || true
@@ -215,10 +299,12 @@ show_status() {
             tmux has-session -t "=$monitor" 2>/dev/null && status="监控中 ($monitor)"
             echo "  $s"
             echo "    目录: $session_dir | 状态: $status"
-            if [ -d "$session_dir/logs" ]; then
+            local log_dir="$session_dir/.wopal-space/logs"
+            [ ! -d "$log_dir" ] && log_dir="$session_dir/logs"
+            if [ -d "$log_dir" ]; then
                 local log_count
-                log_count=$(find "$session_dir/logs" -name "*.log" -type f 2>/dev/null | wc -l | tr -d ' ')
-                [ "$log_count" -gt 0 ] && echo "    日志: $session_dir/logs ($log_count 个)"
+                log_count=$(find "$log_dir" -name "*.log" -type f 2>/dev/null | wc -l | tr -d ' ')
+                [ "$log_count" -gt 0 ] && echo "    日志: $log_dir ($log_count 个)"
             fi
         done
     fi
@@ -241,14 +327,14 @@ show_status() {
     echo ""
     echo "后端服务:"
     if is_backend_running; then
-        local bpid="(unknown)" bdir=""
+        local bpid="(unknown)" bdir="" blog=""
         if [ -f "$BACKEND_PID_FILE" ]; then
-            { read -r bpid; read -r bdir; } < "$BACKEND_PID_FILE"
+            { read -r bpid; read -r bdir; read -r blog || true; } < "$BACKEND_PID_FILE"
         fi
         echo "  运行中 → http://127.0.0.1:$BACKEND_PORT"
         [ -n "$bpid" ] && echo "  PID: $bpid"
         [ -n "$bdir" ] && echo "  目录: $bdir"
-        [ -f "$BACKEND_LOG" ] && echo "  日志: $BACKEND_LOG"
+        [ -n "$blog" ] && [ -f "$blog" ] && echo "  日志: $blog"
     else
         echo "  未运行"
     fi
@@ -261,13 +347,17 @@ case "$COMMAND" in
     stop)   stop_backend; exit 0 ;;
     help)   show_help; exit 0 ;;
     serve)
-        mkdir -p "$LOG_DIR"
         [ "$DEBUG_MODE" = true ] && {
             echo "emt: 调试模式 [$LOG_LEVEL${LOG_MODULES:+:$LOG_MODULES}] → logs/"
         }
         start_backend
         echo -n "emt: 等待后端就绪"
-        wait_backend && echo " OK" || echo " 超时"
+        wait_backend
+        case $? in
+            0) echo " OK" ;;
+            1) local _pid _cwd _log; { read -r _pid; read -r _cwd; read -r _log || true; } < "$BACKEND_PID_FILE"; echo " 超时"; echo "emt: 后端可能仍在启动中，查看日志: ${_log:-未知}" ;;
+            *) exit 1 ;;
+        esac
         echo "emt: 后端已启动 → http://127.0.0.1:$BACKEND_PORT"
         exit 0
         ;;
@@ -304,7 +394,7 @@ start_auto_approve() {
         return
     fi
 
-    local log_arg="$([ -d "$LOG_DIR" ] && echo "$LOG_DIR")"
+    local log_arg="$([ -d "$SPACE_LOG_DIR" ] && echo "$SPACE_LOG_DIR" || echo "$GLOBAL_LOG_DIR")"
     local debug_flag="$([ "$DEBUG_MODE" = true ] && echo true || echo false)"
 
     nohup python3 "$AUTO_APPROVE_SCRIPT" start "$session" "$debug_flag" "10" "$log_arg" \
@@ -323,7 +413,6 @@ create_session() {
         esac
     fi
 
-    mkdir -p "$LOG_DIR"
     [ "$DEBUG_MODE" = true ] && echo "emt: 调试模式 [$LOG_LEVEL${LOG_MODULES:+:$LOG_MODULES}] → logs/"
 
     echo "emt: 创建会话 \"$name\"$([ "$ATTACH_MODE" = true ] && echo " [attach]") → $CWD"
@@ -340,7 +429,8 @@ create_session() {
             echo "emt: 连接已有后端 :$BACKEND_PORT"
         fi
 
-        tmux new-session -s "$name" -c "$CWD" -- \
+        tmux new-session -s "$name" -c "$CWD" \
+            -e "WOPAL_HOME=$WOPAL_HOME_DIR" -- \
             ellamaka attach "http://localhost:$BACKEND_PORT" --dir "$CWD" "${WOPAL_SPACE_ARGS[@]}" "${OPENCODE_ARGS[@]}"
     else
         local debug_args=()
@@ -349,14 +439,17 @@ create_session() {
         fi
 
         if [ "$DEBUG_MODE" = true ]; then
+            local tui_log_dir="${SPACE_LOG_DIR:-$GLOBAL_LOG_DIR}"
             tmux new-session -s "$name" -c "$CWD" \
+                -e "WOPAL_HOME=$WOPAL_HOME_DIR" \
                 -e "WOPAL_PLUGIN_LOG_LEVEL=$LOG_LEVEL" \
                 -e "WOPAL_PLUGIN_LOG_MODULES=$LOG_MODULES" \
-                -e "WOPAL_PLUGIN_LOG_FILE=$LOG_DIR/wopal-plugins-debug.log" \
-                -e "WOPAL_DEBUG_LOG_DIR=$LOG_DIR" \
+                -e "WOPAL_PLUGIN_LOG_FILE=$tui_log_dir/wopal-plugins-debug.log" \
+                -e "WOPAL_DEBUG_LOG_DIR=$tui_log_dir" \
                 -- bash -c 'exec ellamaka "$@" 2>> "'"$ELLAMAKA_LOG"'"' _ "${debug_args[@]}" "${WOPAL_SPACE_ARGS[@]}" "${OPENCODE_ARGS[@]}"
         else
-            tmux new-session -s "$name" -c "$CWD" -- \
+            tmux new-session -s "$name" -c "$CWD" \
+                -e "WOPAL_HOME=$WOPAL_HOME_DIR" -- \
                 ellamaka "${WOPAL_SPACE_ARGS[@]}" "${OPENCODE_ARGS[@]}"
         fi
     fi

--- a/skills/space-master/SKILL.md
+++ b/skills/space-master/SKILL.md
@@ -247,7 +247,7 @@ wopal skills list
 
 ## Tips
 
-1. **Ontology 协作必读** — 贡献/同步上游前读 `references/upstream-sync.md`（仓库拓扑、分支命名、agent 工作流）
+1. **Ontology 协作必读** — 贡献/同步上游前读 `references/ontology-maintenance.md`（check 结果解读、下行同步、上行贡献 PR 流程、冲突解决）
 2. **能力分层必读** — 修改、裁剪或下放 ontology 能力（plugin/skill/agent）前读 `references/capability-layers.md`（层级模型、同步契约、删除安全）
 3. **Agent 驱动的工作流** — ontology 协作操作遵循「读取状态 → 与用户讨论 → 构建命令」模式。先执行 `wopal ontology status` 了解当前状态，再与用户确认后再构建 CLI 命令。不要跳过状态读取步骤。
 4. **Edit in workspace** — `.wopal/skills/<name>/` 可直接编辑

--- a/skills/space-master/references/ontology-maintenance.md
+++ b/skills/space-master/references/ontology-maintenance.md
@@ -1,0 +1,119 @@
+# Ontology Maintenance — Agent Operations Guide
+
+机制设计（四层检测原理、PR merge 策略、超集不变量、上行链条 U1-U5、贡献路径）见 ontology DESIGN §6.8。本指南只定义 agent 执行本体维护时的操作规则：看到什么信号，做什么操作。
+
+---
+
+## 触发条件
+
+- 用户要求检查/更新/贡献本体
+- `/ontology-maintain` 命令
+- 定期维护
+
+---
+
+## 操作流程
+
+### 第一步：Check
+
+```
+wopal ontology check
+```
+
+获取四层检测结果：每个段的 tree hash 门控、文件差异清单、方向信号（downstream/upstream）、merge 冲突预测。
+
+### 第二步：解读信号，确定操作
+
+按优先级从高到低检查：
+
+| 优先级 | 检查项 | 条件 | 操作 |
+|--------|--------|------|------|
+| 1 | worktree 状态 | 有未提交变更 | 先提交 |
+| 2 | D1-D4 downstream | merge-tree clean | `ontology update` |
+| 3 | D1-D4 downstream | merge-tree conflicts | cherry-pick 具体变更，手动解决冲突 |
+| 4 | D5 超集 | FAIL | merge main 到 type/coding 修复 |
+| 5 | D6 downstream | space 落后 type/coding | `space update` |
+| 6 | U1 upstream | space 有有价值变更 | 与用户讨论是否贡献 |
+| 7 | U2/U3 upstream | 本地有未推送变更 | push |
+| 8 | U4/U5 upstream | fork 有待贡献上游的变更 | 与用户讨论是否 PR |
+
+**关键原则**：agent 不自动执行贡献——贡献涉及"哪些变更有普遍价值"的语义判断，必须与用户讨论后决定。下行同步（update）在 merge-tree clean 时可以自动建议执行。
+
+### 第三步：执行下行同步（如有 downstream 信号）
+
+**ontology update（HOME 级）**：
+
+1. `wopal ontology update --confirm`（merge-tree clean 时自动 merge）
+2. 如有冲突 → 报告冲突文件 → 手动解决 → commit
+3. D5 超集 FAIL → merge main 到 type/coding → commit
+4. fork 模式 → push 到 origin
+
+**space update（Space 级）**：
+
+1. `wopal space update --confirm`（在 space worktree 中 merge type/coding）
+2. 如有冲突 → 手动解决（保留空间定制 + 接收本体变更）→ `git add` → `git commit --no-edit`
+
+### 第四步：执行上行贡献（如有 upstream 信号 + 用户确认）
+
+上行是链条，必须从 U1 开始逐级上行：
+
+**U1（space → type/coding）**：
+
+贡献路径选择（与用户讨论后决定）：
+
+| 变更适用范围 | 贡献到 | 方式 |
+|-------------|--------|------|
+| 同类空间通用 | type/coding | 直接 PR 或精选 PR |
+| 所有空间通用 | main | 精选 PR（贡献分支） |
+| 本空间特有 | 不贡献 | 留在 space 分支 |
+
+直接 PR：差异全是通用变更 → 从 space 分支创建 PR 到父层（squash merge）。
+
+精选 PR：混合了通用和私有变更 → 从目标层创建贡献分支 → cherry-pick 选定提交 → PR 贡献分支到目标层。
+
+**U2/U3（local → origin）**：
+
+```
+git push origin main
+git push origin type/coding
+```
+
+**U4/U5（origin → upstream）**：
+
+跨仓库 PR。选择有价值的提交 → cherry-pick 到 contribute 分支 → push → 创建 PR（base = upstream 目标分支）。
+
+---
+
+## 冲突解决规则
+
+### 预测
+
+check 第四层（`git merge-tree`）在执行前预测冲突。clean 时自动 merge；conflicts 时报告冲突文件列表。
+
+### 解决
+
+agent 手动编辑冲突文件，保留双方有价值的改动：
+
+| 冲突类型 | 解决策略 |
+|---------|---------|
+| `settings.jsonc`（尾换行 + 配置块） | 合并保留两者（配置块 + 尾换行） |
+| 上游修改了通用能力，本地也修改了同一文件 | 以上游版本为基，移植本地特有改动 |
+| 双方新增同名文件 | 对比内容，合并两边改动 |
+| 上游删除了文件（下行信号） | 确认删除是否适用于本地空间 |
+
+解决后：`git add <resolved-files>` → `git commit --no-edit` 完成 merge。
+
+---
+
+## PR 规范
+
+所有上行回流采用 PR merge（squash merge）。提交标题遵循 Conventional Commits 格式。贡献分支是临时分支，PR 合并后删除。
+
+---
+
+## 验证
+
+每次操作后验证：
+- 下行同步后：重跑 check 确认 downstream 信号消失
+- 上行贡献后：确认 PR 创建成功，等待合并
+- 超集修复后：D5 段 PASS


### PR DESCRIPTION
## Changes

Generic improvements from wopal-workspace space, promoted from type/coding to main:

- `skills/space-master/SKILL.md` (M): updated skill definition
- `skills/space-master/references/ontology-maintenance.md` (A): new reference doc
- `docs/DESIGN.md` (M): updated design documentation
- `scripts/emt` (M): updated ellamaka management script
- `plugins/wopal-plugin/src/index.ts` (M): plugin improvements
- `.env.example` (M): updated env template

Conflicts with PR #17 resolved using origin/main version (newer).

## Type of change

- [x] Generic capability improvement (applies to all type/* branches)

## Verification

After merge, type/* branches should `git merge main` to inherit these changes.